### PR TITLE
Avoid swallowing error output from apt_get_install

### DIFF
--- a/hooks/shelltoolbox.py
+++ b/hooks/shelltoolbox.py
@@ -77,10 +77,11 @@ def apt_get_install(*args, **kwargs):
     :raises: subprocess.CalledProcessError
     """
     caller = kwargs.pop('caller', run)
+    stderr = kwargs.pop('stderr', None)
     debian_frontend = kwargs.pop('DEBIAN_FRONTEND', 'noninteractive')
     with environ(DEBIAN_FRONTEND=debian_frontend, **kwargs):
         cmd = ('apt-get', '-y', 'install') + args
-        return caller(*cmd)
+        return caller(*cmd, stderr=stderr)
 
 
 def bzr_whois(user):


### PR DESCRIPTION
A user was getting intermittent install hook failures, with the relevant logs here: http://pastebin.ubuntu.com/13503590/

This seems like it could be caused by network issues on the user's environment, but the error from `apt-get` is getting swallowed by the charm.  This should allow the error to show up in the log.