### PR TITLE
Include host and port in the WebSocket template.

### DIFF
--- a/server/guiserver/apps.py
+++ b/server/guiserver/apps.py
@@ -31,6 +31,10 @@ from guiserver.bundles.base import Deployer
 from jujugui import make_application
 
 
+# Define the template to use for building the WebSocket URL.
+WEBSOCKET_URL_TEMPLATE = '/api/$server/$port/$uuid'
+
+
 def server():
     """Return the main server application.
 
@@ -58,6 +62,8 @@ def server():
             'deployer': deployer,
             # The tokens collection for authentication token requests.
             'tokens': tokens,
+            # The WebSocket URL template.
+            'ws_url_template': WEBSOCKET_URL_TEMPLATE,
         }
         juju_proxy_handler_options = {
             'target_url': utils.ws_to_http(options.apiurl),
@@ -90,7 +96,7 @@ def server():
         'jujugui.raw': options.jujuguidebug,
         'jujugui.combine': not options.jujuguidebug,
         'jujugui.apiAddress': options.apiurl,
-        'jujugui.socketTemplate': '/environment/$uuid/api',
+        'jujugui.socketTemplate': WEBSOCKET_URL_TEMPLATE,
         'jujugui.jujuCoreVersion': options.jujuversion,
         'jujugui.jem_url': options.jemlocation,
         'jujugui.uuid': options.uuid,

--- a/server/guiserver/tests/test_apps.py
+++ b/server/guiserver/tests/test_apps.py
@@ -157,7 +157,7 @@ class TestServer(AppsTestMixin, unittest.TestCase):
             'https://api.jujucharms.com/charmstore/',
             config['jujugui.charmstore_url'])
         self.assertEqual(
-            '/environment/$uuid/api', config['jujugui.socketTemplate'])
+            apps.WEBSOCKET_URL_TEMPLATE, config['jujugui.socketTemplate'])
         self.assertTrue(config['jujugui.combine'])
         self.assertFalse(config['jujugui.interactive_login'])
         self.assertFalse(config['jujugui.sandbox'])

--- a/server/guiserver/tests/test_handlers.py
+++ b/server/guiserver/tests/test_handlers.py
@@ -40,6 +40,7 @@ from tornado.testing import (
 import yaml
 
 from guiserver import (
+    apps,
     auth,
     clients,
     get_version,
@@ -80,6 +81,7 @@ class WebSocketHandlerTestMixin(object):
             'deployer': self.deployer,
             'io_loop': self.io_loop,
             'tokens': self.tokens,
+            'ws_url_template': apps.WEBSOCKET_URL_TEMPLATE,
         }
         return web.Application([
             (r'/echo', helpers.EchoWebSocketHandler, echo_options),
@@ -116,7 +118,7 @@ class WebSocketHandlerTestMixin(object):
             headers=headers, mock_protocol=mock_protocol, path=path)
         yield handler.initialize(
             apiurl, self.auth_backend, self.deployer, self.tokens,
-            self.io_loop)
+            apps.WEBSOCKET_URL_TEMPLATE, self.io_loop)
         raise gen.Return(handler)
 
 
@@ -149,11 +151,20 @@ class TestWebSocketHandlerConnection(
         # Make sure that it will initialize with a supplied path.
         with self.mock_websocket_connect() as mock_websocket_connect:
             yield self.make_initialized_handler(
-                path='/ws/environments/1234-1234-1234/api')
+                path='/ws/api/1.2.3.4/17070/1234-1234-1234')
         self.assertEqual(1, mock_websocket_connect.call_count)
         call_args = mock_websocket_connect.call_args[0]
         self.assertEqual(
-            call_args[1], self.apiurl + '/environments/1234-1234-1234/api')
+            call_args[1], 'wss://1.2.3.4:17070/environment/1234-1234-1234/api')
+
+    @gen_test
+    def test_initialize_api_path_legacy(self):
+        # A connection is established to the legacy Juju API endpoint.
+        with self.mock_websocket_connect() as mock_websocket_connect:
+            yield self.make_initialized_handler(path='/ws')
+        self.assertEqual(1, mock_websocket_connect.call_count)
+        call_args = mock_websocket_connect.call_args[0]
+        self.assertEqual(call_args[1], self.apiurl)
 
     @gen_test
     def test_juju_connection_failure(self):
@@ -248,7 +259,7 @@ class TestWebSocketHandlerProxy(
         with mock.patch(mock_path) as mock_write_message:
             initialization = handler.initialize(
                 self.apiurl, self.auth_backend, self.deployer, self.tokens,
-                io_loop=self.io_loop)
+                apps.WEBSOCKET_URL_TEMPLATE, io_loop=self.io_loop)
             handler.on_message(self.hello_message)
             self.assertFalse(mock_write_message.called)
             yield initialization
@@ -301,7 +312,7 @@ class TestWebSocketHandlerAuthentication(
         self.handler = self.make_handler(mock_protocol=True)
         self.handler.initialize(
             self.apiurl, self.auth_backend, self.deployer, self.tokens,
-            io_loop=self.io_loop)
+            apps.WEBSOCKET_URL_TEMPLATE, io_loop=self.io_loop)
 
     def send_login_request(self):
         """Create a login request and send it to the handler."""

--- a/server/guiserver/tests/test_utils.py
+++ b/server/guiserver/tests/test_utils.py
@@ -127,6 +127,29 @@ class TestGetHeaders(unittest.TestCase):
         self.assertEqual({'Origin': 'https://server.example.com'}, headers)
 
 
+class TestGetJujuApiUrl(unittest.TestCase):
+
+    template = '/api/$server/$port/$uuid'
+    default = 'wss://example.com:17070/'
+
+    def test_no_match(self):
+        # The default URL is returned if there is no match.
+        url = utils.get_juju_api_url('/ws', self.template, self.default)
+        self.assertEqual(self.default, url)
+
+    def test_precise_match(self):
+        # The expected URL is returned when the path matches precisely.
+        path = '/api/1.2.3.4/4242/my-uuid'
+        url = utils.get_juju_api_url(path, self.template, self.default)
+        self.assertEqual('wss://1.2.3.4:4242/environment/my-uuid/api', url)
+
+    def test_prefixed_match(self):
+        # The expected URL is returned when the path also includes a prefix.
+        path = '/my/prefix/api/1.2.3.4/47/uuid'
+        url = utils.get_juju_api_url(path, self.template, self.default)
+        self.assertEqual('wss://1.2.3.4:47/environment/uuid/api', url)
+
+
 class TestJoinUrl(unittest.TestCase):
 
     def test_url_parts(self):

--- a/server/guiserver/utils.py
+++ b/server/guiserver/utils.py
@@ -19,6 +19,7 @@
 import collections
 import functools
 import logging
+import re
 import urlparse
 import weakref
 
@@ -59,6 +60,24 @@ def get_headers(request, websocket_url):
     if origin is None:
         origin = ws_to_http(websocket_url)
     return {'Origin': origin}
+
+
+def get_juju_api_url(path, template, default):
+    """Return the Juju WebSocket API fully qualified URL.
+
+    Receives the current WebSocket handler path and the template used by the
+    Juju GUI. If a URL cannot be inferred, return the given default.
+    """
+    pattern = template.replace(
+        '$server', '(?P<server>.*)').replace(
+        '$port', '(?P<port>\d+)').replace(
+        '$uuid', '(?P<uuid>.*)')
+    match = re.search(pattern, path)
+    if match is None:
+        # The path is empty: probably an old Juju version is being used.
+        return default
+    return 'wss://{server}:{port}/environment/{uuid}/api'.format(
+        **match.groupdict())
 
 
 def join_url(base_url, path, query):

--- a/server/guiserver/utils.py
+++ b/server/guiserver/utils.py
@@ -66,7 +66,11 @@ def get_juju_api_url(path, template, default):
     """Return the Juju WebSocket API fully qualified URL.
 
     Receives the current WebSocket handler path and the template used by the
-    Juju GUI. If a URL cannot be inferred, return the given default.
+    Juju GUI. For instance, path is a string representing the path used by the
+    client to connect to the GUI server (like "/ws/api/1.2.3.4/17070/uuid").
+    The template specifies where in the path relevant information can be found:
+    for instance "/api/$server/$port/$uuid".
+    If a URL cannot be inferred as described, return the given default.
     """
     pattern = template.replace(
         '$server', '(?P<server>.*)').replace(


### PR DESCRIPTION
This way the GUI server is able to properly
proxy connections to multiple different controllers.

Tests: `make unittest`.
QA: `make deploy` this charm and ensure the GUI properly
connects to the model/controller.
Also run `app.env.get('socket_url');` in the JS console
and esnure the returned URL makes sense.