### PR TITLE
Properly include /ws in the WebSocket template.

### DIFF
--- a/releases/DO-NOT-RELEASE
+++ b/releases/DO-NOT-RELEASE
@@ -1,0 +1,2 @@
+The charm is currently including a development version of Juju GUI.
+

--- a/server/guiserver/apps.py
+++ b/server/guiserver/apps.py
@@ -32,7 +32,7 @@ from jujugui import make_application
 
 
 # Define the template to use for building the WebSocket URL.
-WEBSOCKET_URL_TEMPLATE = '/api/$server/$port/$uuid'
+WEBSOCKET_URL_TEMPLATE = '/ws/api/$server/$port/$uuid'
 
 
 def server():

--- a/server/guiserver/tests/test_apps.py
+++ b/server/guiserver/tests/test_apps.py
@@ -164,7 +164,7 @@ class TestServer(AppsTestMixin, unittest.TestCase):
         self.assertFalse(config['jujugui.interactive_login'])
         self.assertFalse(config['jujugui.sandbox'])
         self.assertFalse(config['jujugui.raw'])
-        self.assertIsNone(config['jujugui.base_url'])
+        self.assertEqual('', config['jujugui.base_url'])
 
     def test_gui_jem_connection(self):
         # The server can be configured to connect the Juju GUI to a JEM.


### PR DESCRIPTION
Also note that a development (unreleased) version of the GUI tarball is now used.
