### PR TITLE
Fix for when pip -> pip3

### DIFF
--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -286,7 +286,7 @@ def install_builtin_server():
     # from the network.
     with su('root'):
         cmd_log(run(
-            'pip2', 'install', '--no-index', '--no-dependencies',
+            '/usr/bin/pip', 'install', '--no-index', '--no-dependencies',
             '--find-links', 'file:///{}'.format(deps),
             '-r', requirements
         ))

--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -286,7 +286,7 @@ def install_builtin_server():
     # from the network.
     with su('root'):
         cmd_log(run(
-            '/usr/bin/pip', 'install', '--no-index', '--no-dependencies',
+            '/usr/bin/pip2', 'install', '--no-index', '--no-dependencies',
             '--find-links', 'file:///{}'.format(deps),
             '-r', requirements
         ))
@@ -414,7 +414,7 @@ def setup_gui():
     release_tarball_path = get_release_file_path()
     log('Installing Juju GUI from {}.'.format(release_tarball_path))
     cmd = (
-        '/usr/bin/pip',  'install', '--no-index',
+        '/usr/bin/pip2',  'install', '--no-index',
         '--find-links', 'file:///{}'.format(jujugui_deps),
         release_tarball_path,
     )

--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -286,7 +286,7 @@ def install_builtin_server():
     # from the network.
     with su('root'):
         cmd_log(run(
-            'pip', 'install', '--no-index', '--no-dependencies',
+            'pip2', 'install', '--no-index', '--no-dependencies',
             '--find-links', 'file:///{}'.format(deps),
             '-r', requirements
         ))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -887,7 +887,7 @@ class TestInstallBuiltinServer(unittest.TestCase):
         ])
         mock_run.assert_has_calls([
             mock.call(
-                'pip', 'install', '--no-index', '--no-dependencies',
+                '/usr/bin/pip2', 'install', '--no-index', '--no-dependencies',
                 '--find-links', 'file:///{}/deps'.format(charm_dir),
                 '-r', os.path.join(charm_dir, 'server-requirements.pip')),
             mock.call(


### PR DESCRIPTION
When hulk-smashing this charm onto the same host of a reactive charm, juju-gui fails to deploy because pip points to pip3. This fix fixes that