### PR TITLE
Propagate Juju response data when logging in via the token.

### DIFF
--- a/server/guiserver/auth.py
+++ b/server/guiserver/auth.py
@@ -44,6 +44,7 @@ This module includes the pieces required to process user authentication.
       methods.
 """
 
+import copy
 import datetime
 import logging
 import uuid
@@ -370,7 +371,7 @@ class AuthenticationTokenHandler(object):
         This includes the username and password so that clients can then use
         them.  For instance, the GUI stashes them in session storage so that
         reloading the page does not require logging in again."""
-        return {
-            'RequestId': data['RequestId'],
-            'Response': {'AuthTag': user.username, 'Password': user.password}
-        }
+        data = copy.deepcopy(data)
+        response = data.setdefault('Response', {})
+        response.update({'AuthTag': user.username, 'Password': user.password})
+        return data

--- a/server/guiserver/tests/test_auth.py
+++ b/server/guiserver/tests/test_auth.py
@@ -445,8 +445,17 @@ class TestAuthenticationTokenHandler(LogTrapTestCase, unittest.TestCase):
     def test_process_authentication_response(self):
         # It translates a normal authentication success.
         user = auth.User('user-admin', 'ADMINSECRET', True)
-        response = {'RequestId': 42, 'Response': {}}
-        self.assertEqual(
-            dict(RequestId=42,
-                 Response=dict(AuthTag=user.username, Password=user.password)),
-            self.tokens.process_authentication_response(response, user))
+        original_response = {'RequestId': 42, 'Response': {'facades': {}}}
+        expected_response = {
+            'RequestId': 42,
+            'Response': {
+                'facades': {},
+                'AuthTag': user.username,
+                'Password': user.password,
+            },
+        }
+        obtained_response = self.tokens.process_authentication_response(
+            original_response, user)
+        self.assertEqual(expected_response, obtained_response)
+        # The original response is not mutated in the process.
+        self.assertNotEqual(original_response, obtained_response)


### PR DESCRIPTION
It's not easy to QA this, I already did with quickstart, and hopefully the code and the test are clear enough to be trusted. The logic is that when you log in with a timed token, instead of completely rewriting the original response from Juju, we just add to that, so that information now required by the GUI after login (for instance facades information) is still available.
