### PR TITLE
GUI server: disable support for insecure cyphers.

### DIFF
--- a/server/guiserver/__init__.py
+++ b/server/guiserver/__init__.py
@@ -37,7 +37,7 @@ requests to the juju-core HTTPS server. Responses are propagated to the client
 which originally made the request.
 """
 
-VERSION = (0, 6, 0)
+VERSION = (0, 7, 0)
 
 
 def get_version():

--- a/server/guiserver/manage.py
+++ b/server/guiserver/manage.py
@@ -18,6 +18,7 @@
 
 import logging
 import os
+import ssl
 import sys
 
 from tornado.httpclient import AsyncHTTPClient
@@ -35,6 +36,9 @@ from guiserver.apps import (
 )
 
 
+# Define ciphers supported by this server:
+# see <https://www-origin.openssl.org/docs/manmaster/apps/ciphers.html>.
+CIPHERS = 'HIGH:!RC4:!MD5:!aNULL:!eNULL:!EXP:!LOW:!MEDIUM'
 DEFAULT_API_VERSION = 'go'
 DEFAULT_SSL_PATH = '/etc/ssl/juju-gui'
 
@@ -94,6 +98,8 @@ def _get_ssl_options():
     return {
         'certfile': os.path.join(options.sslpath, 'juju.crt'),
         'keyfile': os.path.join(options.sslpath, 'juju.key'),
+        'ssl_version': ssl.PROTOCOL_TLSv1,
+        'ciphers': CIPHERS,
     }
 
 

--- a/server/guiserver/tests/test_manage.py
+++ b/server/guiserver/tests/test_manage.py
@@ -18,6 +18,7 @@
 
 from contextlib import contextmanager
 import logging
+import ssl
 import unittest
 
 import mock
@@ -159,6 +160,8 @@ class TestGetSslOptions(unittest.TestCase):
         expected = {
             'certfile': '/my/path/juju.crt',
             'keyfile': '/my/path/juju.key',
+            'ssl_version': ssl.PROTOCOL_TLSv1,
+            'ciphers': manage.CIPHERS,
         }
         with mock.patch('guiserver.manage.options', mock_options):
             self.assertEqual(expected, manage._get_ssl_options())
@@ -169,6 +172,8 @@ class TestRun(LogTrapTestCase, unittest.TestCase):
     expected_ssl_options = {
         'certfile': '/my/sslpath/juju.crt',
         'keyfile': '/my/sslpath/juju.key',
+        'ssl_version': ssl.PROTOCOL_TLSv1,
+        'ciphers': manage.CIPHERS,
     }
 
     def mock_and_run(self, **kwargs):


### PR DESCRIPTION
QA:
- bootstrap a juju controller on ec2;
- deploy this GUI branch (trusty incarnation) in there: 
  `make deploy SERIES=trusty`;
- wait for the GUI to be deployed;
- go to your AWS management console and copy the dns public 
  name for your "juju-default..." instance, something like 
  `ec2-52-59-34-212.eu-central-1.compute.amazonaws.com`;
- paste that address to the browser and check that, after
  accepting the self-signed cert, you can see the GUI login
  page;
- paste that address also to the form at 
  https://www.ssllabs.com/ssltest/analyze.html and start
  the check, click continue when asked about name mismatch 
  (it will take a couple of minutes);
- when test results are ready, check that we only support TLS,
  that no insecure ciphers can be used, and that RC4 is not
  supported;
- done, destroy your aws controller, thank you!

Fixes: https://github.com/juju/juju-gui/issues/1501