### PR TITLE
Use same SSL protocol for all Python versions.

### DIFF
--- a/server/guiserver/manage.py
+++ b/server/guiserver/manage.py
@@ -95,15 +95,10 @@ def _get_ssl_options():
     The certificate and key file paths are generated using the base SSL path
     included in the options.
     """
-    ssl_version = ssl.PROTOCOL_SSLv23
-    if sys.version_info < (2, 7, 9):
-        # Older Python versions, as the one that can be found on trusty,
-        # unfortunately don't support just disabling SSLv3.
-        ssl_version = ssl.PROTOCOL_TLSv1
     return {
         'certfile': os.path.join(options.sslpath, 'juju.crt'),
         'keyfile': os.path.join(options.sslpath, 'juju.key'),
-        'ssl_version': ssl_version,
+        'ssl_version': ssl.PROTOCOL_SSLv23,
         'ciphers': CIPHERS,
     }
 

--- a/server/guiserver/tests/test_manage.py
+++ b/server/guiserver/tests/test_manage.py
@@ -156,8 +156,8 @@ class TestGetSslOptions(unittest.TestCase):
 
     mock_options = mock.Mock(sslpath='/my/path')
 
-    def test_options_new_python(self):
-        # The SSL options are correctly returned on recent Python versions.
+    def test_options(self):
+        # The SSL options are correctly returned.
         expected = {
             'certfile': '/my/path/juju.crt',
             'keyfile': '/my/path/juju.key',
@@ -165,20 +165,7 @@ class TestGetSslOptions(unittest.TestCase):
             'ciphers': manage.CIPHERS,
         }
         with mock.patch('guiserver.manage.options', self.mock_options):
-            with mock.patch('sys.version_info', (2, 7, 12)):
-                self.assertEqual(expected, manage._get_ssl_options())
-
-    def test_options_old_python(self):
-        # The SSL options are correctly returned on old Python versions.
-        expected = {
-            'certfile': '/my/path/juju.crt',
-            'keyfile': '/my/path/juju.key',
-            'ssl_version': ssl.PROTOCOL_TLSv1,
-            'ciphers': manage.CIPHERS,
-        }
-        with mock.patch('guiserver.manage.options', self.mock_options):
-            with mock.patch('sys.version_info', (2, 7, 6)):
-                self.assertEqual(expected, manage._get_ssl_options())
+            self.assertEqual(expected, manage._get_ssl_options())
 
 
 class TestRun(LogTrapTestCase, unittest.TestCase):
@@ -205,8 +192,7 @@ class TestRun(LogTrapTestCase, unittest.TestCase):
                 mock.patch('guiserver.manage.IOLoop') as ioloop, \
                 mock.patch('guiserver.manage.options', mock.Mock(**options)), \
                 mock.patch('guiserver.manage.redirector') as redirector, \
-                mock.patch('guiserver.manage.server') as server, \
-                mock.patch('sys.version_info', (2, 7, 12)):
+                mock.patch('guiserver.manage.server') as server:
             manage.run()
         return ioloop.instance().start, redirector().listen, server().listen
 


### PR DESCRIPTION
Fixes https://github.com/juju/juju-gui/issues/1501